### PR TITLE
switch to rhel-atomic for init and yaml format fix

### DIFF
--- a/amp/amp-ephemeral.yml
+++ b/amp/amp-ephemeral.yml
@@ -235,8 +235,8 @@ objects:
       spec:
         initContainers:
         - name: backend-redis-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(nc -z backend-redis 6379); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(echo -n > /dev/tcp/backend-redis/6379); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -560,8 +560,8 @@ objects:
       spec:
         initContainers:
         - name: backend-redis-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(nc -z backend-redis 6379); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(echo -n > /dev/tcp/backend-redis/6379); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -767,8 +767,8 @@ objects:
           emptyDir: {}
         initContainers:
         - name: zync-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(wget -qO /dev/null http://zync:8080/status/ready); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(curl --output /dev/null --silent --head --fail http://zync:8080/status/ready); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -1175,8 +1175,8 @@ objects:
       spec:
         initContainers:
         - name: system-master-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(nc -z system-master 3000); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(echo -n > /dev/tcp/system-master/3000); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -1924,10 +1924,10 @@ objects:
       system: postgresql
   spec:
     tags:
-      - name: '9.5'
-        from:
-          kind: DockerImage
-          name: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+    - name: "9.5"
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
 
 - kind: ImageStream
   apiVersion: v1

--- a/amp/amp.yml
+++ b/amp/amp.yml
@@ -294,8 +294,8 @@ objects:
       spec:
         initContainers:
         - name: backend-redis-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(nc -z backend-redis 6379); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(echo -n > /dev/tcp/backend-redis/6379); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -620,8 +620,8 @@ objects:
       spec:
         initContainers:
         - name: backend-redis-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(nc -z backend-redis 6379); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(echo -n > /dev/tcp/backend-redis/6379); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -828,7 +828,7 @@ objects:
           emptyDir: {}
         initContainers:
         - name: zync-svc
-          image: busybox:latest
+          image: registry.access.redhat.com/rhel-atomic:7.5
           command: ['sh', '-c', 'until $(curl --output /dev/null --silent --head --fail http://zync:8080/status/ready); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
@@ -1236,8 +1236,8 @@ objects:
       spec:
         initContainers:
         - name: system-master-svc
-          image: busybox
-          command: ['sh', '-c', 'until $(nc -z system-master 3000); do sleep $SLEEP_SECONDS; done']
+          image: registry.access.redhat.com/rhel-atomic:7.5
+          command: ['sh', '-c', 'until $(echo -n > /dev/tcp/system-master/3000); do sleep $SLEEP_SECONDS; done']
           activeDeadlineSeconds: 600
           env:
           - name: SLEEP_SECONDS
@@ -1989,10 +1989,10 @@ objects:
       system: postgresql
   spec:
     tags:
-      - name: 9.5
-        from:
-          kind: DockerImage
-          name: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
+    - name: "9.5"
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/rhscl/postgresql-95-rhel7:9.5
 
 - kind: ImageStream
   apiVersion: v1


### PR DESCRIPTION
 - use enterprise-ready image for init containers
 - ncat doesn't exist in rhel-atomic so switched to using /dev/tcp for port checks